### PR TITLE
feat: 新增Cookie加载和保存功能实现免密登录，优化登录流程

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from src.configs import Config
 from src.logger import Logger
 from src.crawler import crawl_popular_question, crawl_latest_question
 from src.answer import answer
+from src.utils import load_cookies, save_cookies
 import time
 
 config = Config()
@@ -51,13 +52,20 @@ def open_browser(playwright) -> tuple[Browser, BrowserContext]:
         with open("scripts/stealth.min.js", "r", encoding="utf-8") as f:
             stealth_js = f.read()
         context.add_init_script(stealth_js)
+        # 加载本地Cookie
+        cookies = load_cookies("res/cookies.json")
+        if cookies:
+            context.add_cookies(cookies)  
+            logger.info("已加载本地Cookie，尝试免密登录")
+        else:
+            logger.info("未找到本地Cookie，将进行手动登录")
         return browser, context
     except Exception as e:
         logger.error(f"浏览器启动失败: {e}")
         raise
 
 
-def login(page: Page) -> Page:
+def login(page: Page,context: BrowserContext) -> Page:
     """登录到智慧树网
     Args:
         page: Playwright页面对象
@@ -70,15 +78,17 @@ def login(page: Page) -> Page:
     try:
         # 访问登录页面（设置30秒超时）
         page.goto(config.login_url, timeout=30000)
-        # 定位未登录状态的登录链接并点击
-        login_link = page.locator("#notLogin").get_by_role("link").first
-        login_link.click(timeout=10000)
-
+        # 首次检查URL：如果不含"login"，说明Cookie有效
+        if "login" not in page.url:
+            logger.info("检测到已通过Cookie登录，跳过手动登录")
+            return page
+        logger.info("Cookie无效或未登录，进行手动登录")
+        
         # 填写用户名和密码
         username_input = page.get_by_role("textbox", name="请输入手机号")
-        username_input.fill(str(config.username), timeout=5000)
+        username_input.fill(str(config.username), timeout=10000)
         password_input = page.get_by_role("textbox", name="请输入密码")
-        password_input.fill(str(config.password), timeout=5000)
+        password_input.fill(str(config.password), timeout=10000)
 
         # 点击登录按钮
         page.get_by_text("登 录").click(timeout=5000)
@@ -86,6 +96,10 @@ def login(page: Page) -> Page:
 
         # 等待网络空闲（最长等待60秒）
         page.wait_for_load_state("networkidle", timeout=60000)
+        # 确认登录后再保存Cookie（此时URL已无"login"，确保有效）
+        cookies = context.cookies()
+        save_cookies(cookies, "res/cookies.json")
+        logger.info("已保存有效登录Cookie到: res/cookies.json")
         logger.info("登录成功！")
         return page
     except TimeoutError as e:
@@ -107,7 +121,7 @@ def main():
             # 登录操作
             login_page = context.new_page()
             login_start = time.time()  # 登录计时开始
-            login(login_page)
+            login(login_page,context)
             logger.info(f"登录耗时: {time.time() - login_start:.2f}秒")  # 记录登录耗时
             login_page.close()
 

--- a/main.py
+++ b/main.py
@@ -31,16 +31,20 @@ def open_browser(playwright) -> tuple[Browser, BrowserContext]:
     """
     try:
         # 使用Chromium内核启动浏览器
-        browser = playwright.chromium.launch(
-            channel=config.driver,  # 使用配置中指定的浏览器渠道
-            headless=False,  # 可视化模式运行
-            args=[
+        launch_kwargs = {
+            "channel": config.driver,
+            "headless": False,
+            "args": [
                 "--disable-backgrounding-occluded-windows",
                 "--disable-renderer-backgrounding",
-                "--start-minimized"  # 启动时最小化
+                "--start-minimized", 
                 "--disable-blink-features=AutomationControlled",
-            ],  # 禁用自动化检测特征
-        )
+            ],
+        }
+        if config.browser_path:
+            launch_kwargs["executable_path"] = config.browser_path
+        # 启动浏览器
+        browser = playwright.chromium.launch(**launch_kwargs)
         # 创建新的浏览器上下文
         context = browser.new_context()
         # 加载反检测脚本（避免被识别为自动化工具）

--- a/src/configs.py
+++ b/src/configs.py
@@ -5,7 +5,7 @@ import sys
 
 class Config:
     def __init__(self):
-        self.login_url = "https://www.zhihuishu.com/"
+        self.login_url = "https://passport.zhihuishu.com/login"
         config = self.loading_config()
         if not config:
             Logger().error("配置加载失败，程序无法继续运行。")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,44 @@
 import random
 import time
-
+import os
+import json
 
 def get_random(n: int) -> int:
     random.seed(time.time())
     return random.randint(int(n / 2), int(n * 1.5))
 
+def load_cookies(file_path: str):
+    """加载本地Cookie文件"""
+    if not os.path.exists(file_path):
+        return None
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            cookies = json.load(f)
+        # 新增：校验Cookie是否为空或无效
+        if not cookies or not isinstance(cookies, list) or len(cookies) == 0:
+            print("Cookie文件内容为空或无效")
+            return None
+        return cookies
+    except json.JSONDecodeError:
+        print("Cookie文件格式错误（非有效JSON）")
+        return None
+    except Exception as e:
+        print(f"加载Cookie失败: {e}")
+        return None
 
+def save_cookies(cookies, file_path: str):
+    """保存Cookie到本地文件"""
+    # 创建目录（如果不存在）
+    dir_path = os.path.dirname(file_path)
+    if dir_path and not os.path.exists(dir_path):
+        os.makedirs(dir_path, exist_ok=True)
+    try:
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(cookies, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        print(f"保存Cookie失败: {e}")
+
+        
 # start_time = time.time()  # 总开始时间
 # time.sleep(1)
 # total_time = time.time() - start_time  # 计算总耗时


### PR DESCRIPTION
# **Key Features:**
* 修复了启动参数格式错误和自定义浏览器路径不生效的bug
* 新增了使用Cookie加载和保存功能实现免密登录的功能


# **Implementation Details:**
## 当前实现概览 — 哪些文件负责
- main.py
  - open_browser(): 启动 Playwright 浏览器上下文时调用 `load_cookies("res/cookies.json")`，若返回 cookies 则调用 `context.add_cookies(cookies)` 以尝试注入本地 Cookie，实现免密登录尝试。
  - login(page, context): 访问登录页后检查 `if "login" not in page.url`，若成立则认为通过 Cookie 已登录，跳过手动登录；否则走账号密码填充与滑块处理流程。登录成功后通过 `cookies = await context.cookies()` 读取当前上下文的 Cookie 并 `save_cookies(cookies, "res/cookies.json")` 保存到本地。
- utils.py
  - load_cookies(file_path): 负责读取 cookies.json 文件并做基础校验（是否存在、是否为非空列表、JSON 解析错误捕获）。返回 cookies 列表或 None。
  - save_cookies(cookies, file_path): 将 cookies 列表序列化为 JSON 写入到指定路径（若目录不存在会创建）。
- configpy
  - 修改了原来的config.login_url方便实现免密登录功能

## 具体判定与实现细节
- Cookie 注入
  - 调用 `context.add_cookies(cookies)`。Playwright 的 `add_cookies` 需要每个 cookie 包含至少 name、value、domain/path 或者其它字段；代码直接传入 cookies.json 中的结构，假定它是 Playwright 可接受的 cookie 对象数组。
- 是否免密成功的判定
  - 简单字符串判断：在访问登录页后检查 `if "login" not in page.url`。若登录页 URL 中没有 "login" 子串，认为用户已经被重定向到其它页面（说明凭 cookie 已登录）。
- Cookie 保存
  - 读取 `await context.cookies()` 得到上下文 cookie 列表并直接写入 JSON 文件（覆盖原文件）。写操作在 `src/utils.save_cookies` 作了目录存在性检查。






